### PR TITLE
Fixing link to buster-amd to point to the busterjs account and not johlr...

### DIFF
--- a/extensions/buster-amd.rst
+++ b/extensions/buster-amd.rst
@@ -71,4 +71,4 @@ slash and file suffix. Use this option to e.g. use AMD loader plugins.
 Source code
 ===========
 
-`buster-amd on GitHub <https://github.com/johlrogge/buster-amd>`_
+`buster-amd on GitHub <https://github.com/busterjs/buster-amd>`_


### PR DESCRIPTION
...ogge account
