### PR TITLE
Adding extra installation step in case of failed require of when.js

### DIFF
--- a/developers/environment.rst
+++ b/developers/environment.rst
@@ -43,6 +43,10 @@ dependencies::
 
     buster-dev-tools pull
 
+If you get an error regarding a failed 'when.js' required then run::
+
+    npm install
+
 
 Refreshing all repositories
 ===========================


### PR DESCRIPTION
Encountered this issue when installing the latest buster-dev tools
