### PR TITLE
* improve changelog.rst & developers/environment.rst

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,8 @@ Here you find details about what have changed with each release of Buster.JS.
 v0.6.3
 ======
 
+Not released in `npm <https://npmjs.org/package/buster>`_.
+
 Update capture-server and use new implementation, "ramp". This should
 vastly improve the stability of the server as well as print proper
 error messages (and use correct exit codes) when the server is not
@@ -31,6 +33,8 @@ No additions in this release.
 v0.6.2
 ======
 
+Not released in `npm <https://npmjs.org/package/buster>`_.
+
 Minor fix.
 
 Breaking changes
@@ -51,6 +55,8 @@ Bug fixes
 
 v0.6.1
 ======
+
+Released 2012-07-09.
 
 Buster.JS 0.6.1 is a fairly small maintenance release, mostly correcting a
 bunch of bugs of minor/medium significance.
@@ -101,6 +107,8 @@ Bug fixes
 
 v0.6.0 -- Buster.JS Beta 4
 ==========================
+
+Released 2012-06-20.
 
 Beta 4 packs a lot of changes, increased stability and new features. Tests
 written for older versions do not need any syntactical updates, while

--- a/changelog.rst
+++ b/changelog.rst
@@ -156,7 +156,7 @@ Extension hooks
 ^^^^^^^^^^^^^^^
 
 Hooks fire in a given order. The ``beforeRun`` no longer comes with
-any arguments. To get a hold of the ``analyzer`` and ``configuration`` objects
+any arguments. To get hold of the ``analyzer`` and ``configuration`` objects
 that used to be passed to it, implement ``analyze(analyzer)`` and
 ``configure(configuration)`` (called in that order) in addition.
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -128,7 +128,7 @@ These naming changes will only affect you if you are depending on either of
 these modules in your own projects.
 
 - buster-resources is now `ramp-resources
-  <https://github.com/busterjs/ramp-resources>` (the capture server will
+  <https://github.com/busterjs/ramp-resources>`_ (the capture server will
   eventually become "ramp")
 - buster-args is now `posix-argv-parser
   <https://github.com/busterjs/posix-argv-parser>`_

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,10 +6,10 @@ Changelog
 
 Here you find details about what has changed with each release of Buster.JS.
 
-v0.6.3
-======
+v0.6.12 (formerly: v0.6.3)
+==========================
 
-Not released in `npm <https://npmjs.org/package/buster>`_.
+Released 2012-12-22.
 
 Update capture-server and use new implementation, "ramp". This should
 vastly improve the stability of the server as well as print proper
@@ -30,10 +30,10 @@ Additions
 No additions in this release.
 
 
-v0.6.2
-======
+v0.6.11 (formerly: v0.6.2)
+==========================
 
-Not released in `npm <https://npmjs.org/package/buster>`_.
+Released 2012-12-22.
 
 Minor fix.
 
@@ -51,6 +51,12 @@ Bug fixes
 ---------
 
 - Exit code was always 1 (:issue:`221`)
+
+
+v0.6.2 - v.0.6.10
+=================
+
+To be ignored.
 
 
 v0.6.1

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,7 +4,7 @@
 Changelog
 =========
 
-Here you find details about what have changed with each release of Buster.JS.
+Here you find details about what has changed with each release of Buster.JS.
 
 v0.6.3
 ======

--- a/developers/environment.rst
+++ b/developers/environment.rst
@@ -51,6 +51,7 @@ On Windows (DOS-box)::
 
 Please note that the above commands must be *executed right within your development environment folder*,
 i.e. assuming you did not "cd" anywhere else after the ``git clone`` from the first step.
+Or, put more simply: if you, as advised, just kept copying & pasting - you need not worry :).
 
 Finally you run the tool to get all the buster packages plus external
 dependencies::

--- a/developers/environment.rst
+++ b/developers/environment.rst
@@ -19,7 +19,7 @@ It's invoked by a right-click to bring up the context menu and then selecting "G
 
 The development environment is managed with a CLI (Command Line Interface), ``buster-dev-tools``.
 To bootstrap, you create a folder of your choice, e.g. ``myBusterDevEnv``, to hold
-all the packages, and inside of that you make your clone of ``buster-dev-tools`` from GitHub::
+all the packages. Inside of that you clone ``buster-dev-tools`` from GitHub::
 
     mkdir myBusterDevEnv
     cd myBusterDevEnv

--- a/developers/environment.rst
+++ b/developers/environment.rst
@@ -18,18 +18,22 @@ the so-called "Git Bash" which is (almost) a Unix shell on your Windows system.
 It's invoked by a right-click to bring up the context menu and then selecting "Git Bash" from that.
 
 The development environment is managed with a CLI (Command Line Interface), ``buster-dev-tools``.
-To bootstrap, you create a folder of your choice, e.g. ``myBusterDevEnv``, to hold
+To bootstrap, you create a folder of your choice, e.g. ``busterDevEnv``, to hold
 all the packages. Inside of that you clone ``buster-dev-tools`` from GitHub::
 
-    mkdir myBusterDevEnv
-    cd myBusterDevEnv
+    mkdir busterDevEnv
+    cd busterDevEnv
     git clone https://github.com/busterjs/buster-dev-tools.git
+
+Note: the name ``busterDevEnv`` is the only thing that you might want to change to your liking.
+Everything else can (and should be) copied&pasted as is.
 
 Next, two environment variables need to be adjusted: ``NODE_PATH`` and ``PATH``.
 The former, ``NODE_PATH``, affects where Node.js is looking for packages, 
-and we want it to do so in the development environment (``myBusterDevEnv`` in this example).
+and we want it to do so in the development environment (``busterDevEnv`` in this example).
 However, since ``NODE_PATH`` is pretty central to Node.js, we're going to be a bit paranoid
-and first push its current value onto ``NODE_PATH_OLD``, in a stack-like manner (`LIFO <http://en.wikipedia.org/wiki/LIFO_(computing)>`_).
+and first push its current value onto ``NODE_PATH_OLD``,
+in a stack-like manner (`LIFO <http://en.wikipedia.org/wiki/LIFO_(computing)>`_).
 
 On Linux and Mac OS X (or in Git Bash on Windows)::
 

--- a/developers/environment.rst
+++ b/developers/environment.rst
@@ -15,23 +15,21 @@ For Windows we recommend
 `mysysgit <http://code.google.com/p/msysgit/downloads/list>`_ and
 `TortoiseGit <http://code.google.com/p/tortoisegit>`_. These will also get you
 the so-called "Git Bash" which is (almost) a Unix shell on your Windows system.
-It's invoked by right-clicking and selecting "Git Bash" from the context menu.
+It's invoked by a right-click to bring up the context menu and then selecting "Git Bash" from that.
 
 The development environment is managed with a CLI (Command Line Interface), ``buster-dev-tools``.
 To bootstrap, you create a folder of your choice, e.g. ``myBusterDevEnv``, to hold
-all the packages, and inside get a clone of ``buster-dev-tools`` from GitHub::
+all the packages, and inside of that you make your clone of ``buster-dev-tools`` from GitHub::
 
     mkdir myBusterDevEnv
     cd myBusterDevEnv
     git clone https://github.com/busterjs/buster-dev-tools.git
 
 Next, two environment variables need to be adjusted: ``NODE_PATH`` and ``PATH``.
-The former, ``NODE_PATH``, affects where Node.js is looking for packages; 
-it should do so in your development environment (``myBusterDevEnv`` in this example).
-Since ``NODE_PATH`` is pretty central to Node.js we're going to be a bit paranoid
-and push its current value onto ``NODE_PATH_OLD``, in a stack-like manner (LIFO).
-Please note that the following must be executed right within your development environment folder,
-i.e. assuming you did not "cd" anywhere else after the ``git clone`` above.
+The former, ``NODE_PATH``, affects where Node.js is looking for packages, 
+and we want it to do so in the development environment (``myBusterDevEnv`` in this example).
+However, since ``NODE_PATH`` is pretty central to Node.js, we're going to be a bit paranoid
+and first push its current value onto ``NODE_PATH_OLD``, in a stack-like manner (`LIFO <http://en.wikipedia.org/wiki/LIFO_(computing)>`_).
 
 On Linux and Mac OS X (or in Git Bash on Windows)::
 
@@ -47,7 +45,10 @@ On Windows (DOS-box)::
     SET PATH=%NODE_PATH%\buster-dev-tools\bin;%PATH%
     SET PATH=%NODE_PATH%\buster\bin;%PATH%
 
-Now you run the tool to get all the buster packages plus external
+Please note that the above commands must be *executed right within your development environment folder*,
+i.e. assuming you did not "cd" anywhere else after the ``git clone`` from the first step.
+
+Finally you run the tool to get all the buster packages plus external
 dependencies::
 
     buster-dev-tools pull

--- a/developers/environment.rst
+++ b/developers/environment.rst
@@ -13,28 +13,37 @@ on your system.  The same goes for `Git <http://git-scm.com/>`_.
 
 For Windows we recommend
 `mysysgit <http://code.google.com/p/msysgit/downloads/list>`_ and
-`TortoiseGit <http://code.google.com/p/tortoisegit>`_.
+`TortoiseGit <http://code.google.com/p/tortoisegit>`_. These will also get you
+the so-called "Git Bash" which is (almost) a Unix shell on your Windows system.
+It's invoked by right-clicking and selecting "Git Bash" from the context menu.
 
-The development environment is managed with a CLI, ``buster-dev-tools``. To
-bootstrap, you create a folder of your choice, e.g. ``myBusterDevEnv``, to hold
+The development environment is managed with a CLI (Command Line Interface), ``buster-dev-tools``.
+To bootstrap, you create a folder of your choice, e.g. ``myBusterDevEnv``, to hold
 all the packages, and inside get a clone of ``buster-dev-tools`` from GitHub::
 
     mkdir myBusterDevEnv
     cd myBusterDevEnv
     git clone https://github.com/busterjs/buster-dev-tools.git
 
-Now you need to set some environment variables. ``{path to devEnv}`` is the
-absolute path to the folder where you just ran ``git clone``.
+Next, two environment variables need to be adjusted: ``NODE_PATH`` and ``PATH``.
+The former, ``NODE_PATH``, affects where Node.js is looking for packages; 
+it should do so in your development environment (``myBusterDevEnv`` in this example).
+Since ``NODE_PATH`` is pretty central to Node.js we're going to be a bit paranoid
+and push its current value onto ``NODE_PATH_OLD``, in a stack-like manner (LIFO).
+Please note that the following must be executed right within your development environment folder,
+i.e. assuming you did not "cd" anywhere else after the ``git clone`` above.
 
-On Linux and Mac OS X::
+On Linux and Mac OS X (or in Git Bash on Windows)::
 
-    export NODE_PATH=<kbd>{path to devEnv}</kbd>
+    export NODE_PATH_OLD=$NODE_PATH:$NODE_PATH_OLD
+    export NODE_PATH=`pwd`
     export PATH=$NODE_PATH/buster-dev-tools/bin:$PATH
     export PATH=$NODE_PATH/buster/bin:$PATH
 
-On Windows::
+On Windows (DOS-box)::
 
-    SET NODE_PATH=<kbd>{path to devEnv}</kbd>
+    SET NODE_PATH_OLD=%NODE_PATH%;%NODE_PATH_OLD%
+    SET NODE_PATH=%CD%
     SET PATH=%NODE_PATH%\buster-dev-tools\bin;%PATH%
     SET PATH=%NODE_PATH%\buster\bin;%PATH%
 


### PR DESCRIPTION
instructions on environment.rst less platform specific, can now be pasted&copied as is

re changelog.rst: should the other npm-releases appear in changelog.rst, too?
(0.6.4 - 0.6.12, via `npm view buster`)

re which branch to send pull reqs to: plz see ["buster-docs: pull requests for branch master or rather develop only?" on dev mailing list](https://groups.google.com/forum/#!topic/busterjs-dev/mnJGs92rY_8)
