### PR TITLE
- no need to `npm install` by hand anymore 

### DIFF
--- a/developers/environment.rst
+++ b/developers/environment.rst
@@ -58,10 +58,6 @@ dependencies::
 
     buster-dev-tools pull
 
-If you get an error regarding a failed 'when.js' required then run::
-
-    npm install
-
 
 Refreshing all repositories
 ===========================


### PR DESCRIPTION
...as of https://github.com/busterjs/buster-dev-tools/commit/c6360b9dabba1fc14345dfe0f3464fde6e50ca90

see also: https://github.com/busterjs/buster-docs/pull/6 and https://github.com/busterjs/buster-docs/pull/9
