### PR TITLE
async tests: 'done' as callback vs 'done' as factory

### DIFF
--- a/overview.rst
+++ b/overview.rst
@@ -368,10 +368,10 @@ Basically, there are two ways of making a test function asynchronous:
 
 - by returning a :ref:`thenable promise <returning-a-promise>`
 
-- by obtaining a callback from Buster.JS and calling it to signal that the async test has indeed finished (described here)
+- by obtaining a callback from Buster.JS and calling it to signal that the async test has indeed finished
 
-The latter (described here) comes itself in two variants.
-In both of these, have the test function take one argument, ``done``, to tag it as async::
+The latter (described here) comes itself in two variants, both of which
+require the test function to take one argument, ``done``::
 
     buster.testCase("My thing", {
         "test not asynchronous": function () {

--- a/overview.rst
+++ b/overview.rst
@@ -370,7 +370,8 @@ Basically, there are two ways of making a test function asynchronous:
 
 - by obtaining a callback from Buster.JS and calling it to signal that the async test has indeed finished (described here)
 
-To tag a test as async, have the test function take one argument, ``done``::
+The latter (described here) comes itself in two variants.
+In both of these, have the test function take one argument, ``done``, to tag it as async::
 
     buster.testCase("My thing", {
         "test not asynchronous": function () {
@@ -385,7 +386,9 @@ To tag a test as async, have the test function take one argument, ``done``::
         }
     });
 
-If you *don't* call ``done``, the test will eventually time out and fail.
+Here, said callback simply is the ``done`` function.
+You call it after all assertions, with no arguments.
+If you *don't*, the test will eventually time out and fail.
 
 Alternatively, the function passed to your test method can be used as a
 *factory*, to construct the actual callback from your assertions::


### PR DESCRIPTION
added explanations in overview.rst. But _only there_, for now. Let's continue the [discussion on IRC](http://irclogger.com/.buster.js/2013-01-14) here.

To be discussed:
- maybe now too long for a section in overview?
- maybe use `makeDone` or similar as parameter name in "factory" example?
- the "factory" usage is most probably always superior, but why exactly?
- how big a pitfall is passing `done` as a callback itself?

The last one deserves exemplification:

``` javascript
"might work as expected": function (done) {
    this.httpServer.on("close", done);
    // act: trigger this.httpServer.close();
}
```

would just pass if "fail-on-no-assertions" is switched off.

In contrast, 

``` javascript
"will strangely fail": function (done) {
    this.httpServer.on("connect", done);
    // act: trigger connection to this.httpServer
}
```

will probably fail with an error from within `done`. Or it might just time out.
This is because `done` will be invoked in the wrong way, ie. with arguments - and thus will behave fundamentally different.

Q: is just discouraging such use enough? Or, as we're still in beta, should the "simple" use of `done` be thrown away altogether and _only_ the "factory" use be supported? What's the cost of such a drastic step (eg. how many tests of buster itself to rewrite)?

Having only one way ("factory") is obviously advantageous, easier to explain, less error-prone etc. What I'm not sure of is whether it's affordable...

TODO: 
- update https://github.com/meisl/buster-docs/blob/master/modules/buster-test/test-case.rst#asynchronous-tests
- update https://github.com/meisl/buster-docs/blob/master/modules/buster-test/spec.rst#asynchronous-specs
- anywhere else?
