### PR TITLE
Fix typo testRunner.failOnNoAssertions, 's' was missing from the end.

### DIFF
--- a/modules/buster-test/runner.rst
+++ b/modules/buster-test/runner.rst
@@ -323,7 +323,7 @@ assigning to the property on an existing runner::
     runner.timeout = 500;
 
 
-.. attribute:: testRunnerOptions.failOnNoAssertion:
+.. attribute:: testRunnerOptions.failOnNoAssertions:
 
     Default: ``true``
 


### PR DESCRIPTION
Another single character pull request
