### PR TITLE
Update buster-assertions.rst

### DIFF
--- a/modules/buster-assertions.rst
+++ b/modules/buster-assertions.rst
@@ -1015,7 +1015,6 @@ For ``refute`` the behaviour is exactly opposed.
 
 *Overview:*
 
-- :func:`same`
 - :func:`called`
 - :func:`callOrder`
 - :func:`calledOnce`


### PR DESCRIPTION
`same` removed from the overview list of stubs and spies
