### PR TITLE
Module buster-assertions is now called referee.

### DIFF
--- a/developers/architecture.rst
+++ b/developers/architecture.rst
@@ -7,7 +7,8 @@ Architecture overview
 Buster.JS consists of many small Git repositories/npm modules. We try to keep
 things small and separated. The repositories and installable modules both
 promotes reusability (e.g. you can use `Buster assertions with any test
-framework <http://cjohansen.no/using-buster-assertions-with-jstestdriver>`_)
+framework
+<http://cjohansen.no/using-the-referee-assertion-library-with-jstestdriver>`_)
 and helps us avoid tight coupling between modules. However, some people feel
 that the number of repositories are a bit daunting when trying to contribute.
 This document sheds some light on existing modules, what they're for, and what
@@ -102,25 +103,6 @@ The analyzer also comes with a reporter which can be used to log events of
 interest. The analyzer and the reporter is used by buster-test-cli and
 extensions to provide various insight about your code. Examples of practical
 usage includes linting and syntax checking (for browser tests).
-
-
-buster-assertions
------------------
-
-Status:
-    Stable, awaiting a few additions before 1.0
-
-Source code:
-    :repo:`buster-assertions`
-
-Build status:
-    .. raw:: html
-
-        <a href="http://travis-ci.org/busterjs/buster-assertions" class="travis">
-          <img src="https://secure.travis-ci.org/busterjs/buster-assertions.png">
-        </a>
-
-Assertions and expectations, for Buster.JS and everyone else.
 
 
 buster-autotest
@@ -577,6 +559,25 @@ General purpose command line argument parser. Only parses command line options,
 no printing to the console, no ``--help`` generation, no flow control. Also
 tries as best it can to adhere to UNIX conventions. Fails early (typically when
 using non-existent options ++).
+
+
+referee
+-------
+
+Status:
+    Stable, awaiting a few additions before 1.0
+
+Source code:
+    :repo:`referee`
+
+Build status:
+    .. raw:: html
+
+        <a href="http://travis-ci.org/busterjs/referee" class="travis">
+          <img src="https://secure.travis-ci.org/busterjs/referee.png">
+        </a>
+
+Assertions and expectations, for Buster.JS and everyone else.
 
 
 Auxilliary modules

--- a/getting-started.rst
+++ b/getting-started.rst
@@ -131,7 +131,7 @@ If your test is a Node.js test, you also need to require Buster.JS::
         }
     });
 
-See the full :ref:`buster-test-case` docs and :ref:`buster-assertions` docs
+See the full :ref:`buster-test-case` docs and :ref:`referee` docs
 for details. There are also mocks and stubs and more, via the
 :ref:`buster-sinon` module.
 

--- a/modules/buster-configuration.rst
+++ b/modules/buster-configuration.rst
@@ -330,7 +330,7 @@ The individual object in the configuration's list of groups.
 
         configGroup.setupFrameworkResources();
 
-      Adds all the framework resources such as :ref:`buster-assertions`,
+      Adds all the framework resources such as :ref:`referee`,
       :ref:`buster-test` and Sinon to the resource set for the group. These
       resources are prepended so they appear before the files of the config
       group, so that everything is loaded beforehand.

--- a/modules/buster-sinon.rst
+++ b/modules/buster-sinon.rst
@@ -11,7 +11,7 @@ buster-sinon
 .. warning:
   This documentation is incomplete.
 
-Sinon specific assertions are documented at :ref:`buster-assertions`.
+Sinon specific assertions are documented at :ref:`referee`.
 
 Refer to `the Sinon.JS documentation <http://sinonjs.org/docs/>`_ and do some
 guesswork for the other functionality.

--- a/modules/buster-test/runner.rst
+++ b/modules/buster-test/runner.rst
@@ -276,7 +276,7 @@ Methods
     Because the runner itself has no knowledge of the assertion library, this
     method is intended to be overridden by the assertion library in use. For
     instance, this is the integration necessary to count assertions with
-    :ref:`buster-assertions`::
+    :ref:`referee`::
 
         var assertions = 0;
 

--- a/modules/index.rst
+++ b/modules/index.rst
@@ -5,7 +5,6 @@ Core modules
 .. toctree::
     :maxdepth: 2
 
-    buster-assertions
     buster-capture-server
     buster-configuration
     buster-core
@@ -18,5 +17,6 @@ Core modules
     evented-logger
     posix-argv-parser
     prefsink
+    referee
     samsam
     user-agent-parser

--- a/modules/referee.rst
+++ b/modules/referee.rst
@@ -1,25 +1,23 @@
 .. default-domain:: js
 .. highlight:: javascript
-.. _buster-assertions:
+.. _referee:
 
 =================
-buster-assertions
+referee
 =================
 
-Version:
-    0.10.1 (2012-04-26)
 Module:
-    ``require("buster-assertions");``
+    ``require("referee");``
 In browsers:
     ``buster.assertions;``
 
 A collection of assertions to be used with a unit testing framework.
-**buster-assertions** works well with any CommonJS compliant testing framework
+**referee** works well with any CommonJS compliant testing framework
 out of the box, and can easily be configured to work with most any testing
 framework. See also :ref:`expectations` if you like the alternative API
 (``expect(thing).toBe*``).
 
-**buster-assertions** contains lots of assertions. We
+**referee** contains lots of assertions. We
 strongly believe that high-level assertions are essential in the
 interest of producing clear and intent-revealing tests, and they also
 give you to-the-point failure messages.
@@ -28,13 +26,13 @@ give you to-the-point failure messages.
 Assertions and refutations
 ==========================
 
-Unlike most assertion libraries, **buster-assertion** does not have
+Unlike most assertion libraries, **referee** does not have
 ``assert.notXyz`` assertions to refute some fact. Instead, it has
 *refutations*, heavily inspired by Ruby's `minitest
 <http://bfts.rubyforge.org/minitest/>`_::
 
-    var assert = buster.assertions.assert;
-    var refute = buster.assertions.refute;
+    var assert = buster.assertions.assert;    // or short: buster.assert
+    var refute = buster.assertions.refute;    // or short: buster.refute
 
     assert.equals(42, 42);
     refute.equals(42, 43);
@@ -1007,7 +1005,7 @@ The default Buster.JS bundle comes with built-in spies, stubs and mocks
 provided by `Sinon.JS <http://sinonjs.org>`_. The assertions are indisposable
 when working with spies and stubs. However, note that these assertions are
 technically provided by the integration package :ref:`buster-sinon`, *not*
-**buster-assertions**. This only matters if you use this package stand-alone.
+**referee**. This only matters if you use this package stand-alone.
 
 As for the normal assertions, the assertions for stubs and spies can be used with ``assert`` and ``refute``.
 The description is for ``assert``, but the corresponding failure messages for ``refute`` are also mentioned.
@@ -1580,7 +1578,7 @@ For ``refute`` the behaviour is exactly opposed.
 Expectations
 ============
 
-All of buster-assertion's assertions and refutations are also exposed as
+All of referee's assertions and refutations are also exposed as
 "expectations". Expectations is just a slightly different front-end to the same
 functionality, often preferred by the BDD inclined.
 
@@ -1874,7 +1872,7 @@ Methods
     behavior is not suitable for your testing framework of choice, you can
     override :func:`assertions.fail` to make it do the right thing.
 
-    Example: To use **buster-assertions** with JsTestDriver, you can simply
+    Example: To use **referee** with JsTestDriver, you can simply
     configure it as follows::
 
         buster.assertions.fail = function (message) {

--- a/modules/referee.rst
+++ b/modules/referee.rst
@@ -2,9 +2,9 @@
 .. highlight:: javascript
 .. _referee:
 
-=================
+=======
 referee
-=================
+=======
 
 Module:
     ``require("referee");``

--- a/overview.rst
+++ b/overview.rst
@@ -169,7 +169,7 @@ For more, see :ref:`node-testing`.
 Assertions
 ==========
 
-Buster.JS comes :ref:`packed with assertions <buster-assertions>`, and a simple
+Buster.JS comes :ref:`packed with assertions <referee>`, and a simple
 DSL to add app-specific custom assertions::
 
     assert(true);
@@ -230,7 +230,7 @@ too::
         }
     });
 
-For more, see :ref:`buster-assertions`.
+For more, see :ref:`referee`.
 
 
 BDD syntax
@@ -658,13 +658,13 @@ Modularity
 Buster.JS consists of many stand-alone modules with a documented API that can
 be re-used for various purposes.
 
-The :ref:`buster-assertions` package can easily be used in other testing
+The :ref:`referee` package can easily be used in other testing
 frameworks. If you use JsTestDriver, follow `these steps
-<http://cjohansen.no/using-buster-assertions-with-jstestdriver>`_
+<http://cjohansen.no/using-the-referee-assertion-library-with-jstestdriver>`_
 (hint: it's pretty easy).
 
 If you write your own testing framework, you may find many of our modules
-useful. :ref:`buster-assertions` is one such module, and is completely
+useful. :ref:`referee` is one such module, and is completely
 reusable. You can also use :ref:`buster-capture-server` if you want browser
 automation in your test framework, without implementing the actual browser
 automation part yourself.


### PR DESCRIPTION
@cjohansen, @jodal: Can either of you both please review my changes before we merge them into the busterjs/buster-docs repository?
