### PR TITLE
Mention resource file path is relative to rootPath

### DIFF
--- a/modules/buster-configuration.rst
+++ b/modules/buster-configuration.rst
@@ -411,7 +411,7 @@ Content/file resources
 
 ``file``:
     File to serve. When ``file`` is set, you can not set ``combine`` or
-    ``content``.
+    ``content``. The ``file`` path is relative to the ``rootPath``.
 
 
 Proxy resources


### PR DESCRIPTION
It would be helpful to have the content/file resources path property documentation to mention that the file path is relative to the rootPath.

``` javascript
{
    path: 'path/to/a/file.js',
    file: '../some/other/folder/path/to/a/file.js'
}
```
